### PR TITLE
fix: filename error in section 3.7 srcfile

### DIFF
--- a/docs/tutorials/tictoc/part3.md
+++ b/docs/tutorials/tictoc/part3.md
@@ -259,7 +259,7 @@ use RNG 0.
 !!! tip "Exercise"
     Try other distributions as well.
 
-Sources: <a srcfile="tutorials/tictoc/code/tictoc8.ned"></a>, <a srcfile="tutorials/tictoc/code/txc7.cc"></a>, <a srcfile="tutorials/tictoc/code/omnetpp.ini"></a>
+Sources: <a srcfile="tutorials/tictoc/code/tictoc7.ned"></a>, <a srcfile="tutorials/tictoc/code/txc7.cc"></a>, <a srcfile="tutorials/tictoc/code/omnetpp.ini"></a>
 
 
 ## 3.8 Timeout, cancelling timers


### PR DESCRIPTION
Hi,

the link to the src file in section 3.7 of the tictoc tutorial is, I guess, not correct.

I fixed this in this commit.