### PR TITLE
Fix a syntax error and a 404 link

### DIFF
--- a/docs/tutorials/tictoc/part4.md
+++ b/docs/tutorials/tictoc/part4.md
@@ -121,7 +121,7 @@ The message class specification is in `tictoc13.msg`:
 <pre class="snippet" src="../code/tictoc13.msg" from="message TicTocMsg13" upto="}"></pre>
 
 !!! note
-    See <a href="../manual/index.html#cha:msg-def" target="_blank">Section 6</a> of the OMNeT++ manual for more details on messages.
+    See <a href="https://doc.omnetpp.org/omnetpp/manual/#cha:msg-def" target="_blank">Section 6</a> of the OMNeT++ manual for more details on messages.
 
 The makefile is set up so that the message compiler, opp_msgc is invoked
 and it generates `tictoc13_m.h` and `tictoc13_m.cc` from the message declaration

--- a/docs/tutorials/tictoc/part4.md
+++ b/docs/tutorials/tictoc/part4.md
@@ -159,7 +159,7 @@ following:
 In the next line, we check if the destination address is the same as the
 node's address. The `getIndex()` member function returns the index
 of the module in the submodule vector (remember, in the NED file we
-declarared it as `tic: Txc13[6]`, so our nodes have addresses 0..5).
+declarared it as `tic[6]: Txc13`, so our nodes have addresses 0..5).
 
 To make the model execute longer, after a message arrives to its destination
 the destination node will generate another message with a random destination


### PR DESCRIPTION
from `tic: Txc13[6]` to `tic[6]: Txc13`